### PR TITLE
Support vaadin 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Vaadin Gradle Plugin
 
 This is an experimental version of the official Vaadin Gradle Plugin for Vaadin 14
-(Vaadin 15 is not supported at the moment, please see [#50](https://github.com/vaadin/vaadin-gradle-plugin/issues/50) for more details).
-The implementation is now mostly based on the similar Maven plugin.
+and newer. The implementation is now mostly based on the similar Maven plugin.
 Compared to Maven plugin, there are the following limitations:
 
 * Vaadin 14 Compatibility mode is not supported
@@ -43,7 +42,7 @@ Compatibility chart:
 | 0.6.0 and lower              | Vaadin 14.1.x and lower |
 | 0.7.0                        | Vaadin 14.2.x |
 | 0.8.0                        | Vaadin 14.3.x and higher |
-| -                            | Vaadin 15 and higher are currently unsupported |
+| -                            | Vaadin 15 and higher |
 
 ## Tasks
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Compatibility chart:
 | -                            | Vaadin 13 and lower are unsupported |
 | 0.6.0 and lower              | Vaadin 14.1.x and lower |
 | 0.7.0                        | Vaadin 14.2.x |
-| 0.8.0                        | Vaadin 14.3.x and higher |
-| -                            | Vaadin 15 and higher |
+| 0.8.0                        | All other Vaadin 14 versions |
+| -                            | Vaadin 17 |
 
 ## Tasks
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Compatibility chart:
 | 0.6.0 and lower              | Vaadin 14.1.x and lower |
 | 0.7.0                        | Vaadin 14.2.x |
 | 0.8.0                        | All other Vaadin 14 versions |
-| -                            | Vaadin 17 |
+| -                            | Vaadin 17 and higher |
 
 ## Tasks
 

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,8 @@ repositories {
 
 dependencies {
     compile("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72")
-    compile("com.vaadin:flow-migration:2.3.0")
+    compile("com.vaadin:flow-server:3.1.1")
+    compile("org.reflections:reflections:0.9.11")
     compile("org.zeroturnaround:zt-exec:1.11")
 
     testCompile("junit:junit:4.12")

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ repositories {
 
 dependencies {
     compile("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72")
-    compile("com.vaadin:flow-server:3.1.1")
+    compile("com.vaadin:flow-server:4.0.0.beta1")
     compile("org.reflections:reflections:0.9.11")
     compile("org.zeroturnaround:zt-exec:1.11")
 

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,7 @@ repositories {
     mavenCentral()
     jcenter()
     maven { url = 'https://plugins.gradle.org/m2/' }
+    maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ repositories {
 
 dependencies {
     compile("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72")
-    compile("com.vaadin:flow-server:4.0.0.beta1")
+    compile("com.vaadin:flow-server:4.0.0.rc1")
     compile("org.reflections:reflections:0.9.11")
     compile("org.zeroturnaround:zt-exec:1.11")
 

--- a/src/functionalTest/kotlin/com/vaadin/gradle/AbstractGradleTest.kt
+++ b/src/functionalTest/kotlin/com/vaadin/gradle/AbstractGradleTest.kt
@@ -17,6 +17,7 @@ import java.io.File
 abstract class AbstractGradleTest {
 
     val vaadin14Version = "14.2.1"
+    val vaadin16Version = "16.0.0"
 
     /**
      * The testing Gradle project. Automatically deleted after every test.

--- a/src/functionalTest/kotlin/com/vaadin/gradle/AbstractGradleTest.kt
+++ b/src/functionalTest/kotlin/com/vaadin/gradle/AbstractGradleTest.kt
@@ -16,8 +16,7 @@ import java.io.File
  */
 abstract class AbstractGradleTest {
 
-    val vaadin14Version = "14.2.1"
-    val vaadin16Version = "16.0.0"
+    val vaadin17Version = "17.0.0.beta1"
 
     /**
      * The testing Gradle project. Automatically deleted after every test.

--- a/src/functionalTest/kotlin/com/vaadin/gradle/MiscMultiModuleTest.kt
+++ b/src/functionalTest/kotlin/com/vaadin/gradle/MiscMultiModuleTest.kt
@@ -31,7 +31,7 @@ class MiscMultiModuleTest : AbstractGradleTest() {
                 
                 dependencies {
                     compile project(':lib')
-                    compile("com.vaadin:vaadin-core:$vaadin16Version") {
+                    compile("com.vaadin:vaadin-core:$vaadin17Version") {
                 //         Webjars are only needed when running in Vaadin 13 compatibility mode
                         ["com.vaadin.webjar", "org.webjars.bowergithub.insites",
                          "org.webjars.bowergithub.polymer", "org.webjars.bowergithub.polymerelements",
@@ -76,7 +76,7 @@ class MiscMultiModuleTest : AbstractGradleTest() {
                 
                 dependencies {
                     compile project(':lib')
-                    compile("com.vaadin:vaadin-core:$vaadin16Version") {
+                    compile("com.vaadin:vaadin-core:$vaadin17Version") {
                 //         Webjars are only needed when running in Vaadin 13 compatibility mode
                         ["com.vaadin.webjar", "org.webjars.bowergithub.insites",
                          "org.webjars.bowergithub.polymer", "org.webjars.bowergithub.polymerelements",

--- a/src/functionalTest/kotlin/com/vaadin/gradle/MiscMultiModuleTest.kt
+++ b/src/functionalTest/kotlin/com/vaadin/gradle/MiscMultiModuleTest.kt
@@ -31,7 +31,7 @@ class MiscMultiModuleTest : AbstractGradleTest() {
                 
                 dependencies {
                     compile project(':lib')
-                    compile("com.vaadin:vaadin-core:$vaadin14Version") {
+                    compile("com.vaadin:vaadin-core:$vaadin16Version") {
                 //         Webjars are only needed when running in Vaadin 13 compatibility mode
                         ["com.vaadin.webjar", "org.webjars.bowergithub.insites",
                          "org.webjars.bowergithub.polymer", "org.webjars.bowergithub.polymerelements",
@@ -76,7 +76,7 @@ class MiscMultiModuleTest : AbstractGradleTest() {
                 
                 dependencies {
                     compile project(':lib')
-                    compile("com.vaadin:vaadin-core:$vaadin14Version") {
+                    compile("com.vaadin:vaadin-core:$vaadin16Version") {
                 //         Webjars are only needed when running in Vaadin 13 compatibility mode
                         ["com.vaadin.webjar", "org.webjars.bowergithub.insites",
                          "org.webjars.bowergithub.polymer", "org.webjars.bowergithub.polymerelements",

--- a/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
+++ b/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
@@ -4,7 +4,6 @@ import com.vaadin.flow.server.frontend.FrontendUtils
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
-import org.junit.Ignore
 import org.junit.Test
 import java.io.File
 import java.io.IOException
@@ -56,8 +55,8 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                 maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
             }
             dependencies {
-                // Vaadin 16
-                compile("com.vaadin:vaadin-core:$vaadin16Version") {
+                // Vaadin 17
+                compile("com.vaadin:vaadin-core:$vaadin17Version") {
             //         Webjars are only needed when running in Vaadin 13 compatibility mode
                     ["com.vaadin.webjar", "org.webjars.bowergithub.insites",
                      "org.webjars.bowergithub.polymer", "org.webjars.bowergithub.polymerelements",
@@ -101,8 +100,8 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                 optimizeBundle = true
             }
             dependencies {
-                // Vaadin 16
-                compile("com.vaadin:vaadin-core:$vaadin16Version") {
+                // Vaadin 17
+                compile("com.vaadin:vaadin-core:$vaadin17Version") {
             //         Webjars are only needed when running in Vaadin 13 compatibility mode
                     ["com.vaadin.webjar", "org.webjars.bowergithub.insites",
                      "org.webjars.bowergithub.polymer", "org.webjars.bowergithub.polymerelements",
@@ -145,8 +144,8 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                 optimizeBundle = true
             }
             dependencies {
-                // Vaadin 16
-                compile("com.vaadin:vaadin-core:$vaadin16Version") {
+                // Vaadin 17
+                compile("com.vaadin:vaadin-core:$vaadin17Version") {
             //         Webjars are only needed when running in Vaadin 13 compatibility mode
                     ["com.vaadin.webjar", "org.webjars.bowergithub.insites",
                      "org.webjars.bowergithub.polymer", "org.webjars.bowergithub.polymerelements",
@@ -196,8 +195,8 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                 optimizeBundle = true
             }
             dependencies {
-                // Vaadin 16
-                compile("com.vaadin:vaadin-core:$vaadin16Version") {
+                // Vaadin 17
+                compile("com.vaadin:vaadin-core:$vaadin17Version") {
             //         Webjars are only needed when running in Vaadin 13 compatibility mode
                     ["com.vaadin.webjar", "org.webjars.bowergithub.insites",
                      "org.webjars.bowergithub.polymer", "org.webjars.bowergithub.polymerelements",
@@ -238,7 +237,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
      * This build script covers the [Spring Boot example](https://github.com/vaadin/base-starter-spring-gradle)
      */
     @Test
-    fun testVaadin16SpringProjectProductionMode() {
+    fun testVaadin17SpringProjectProductionMode() {
         buildFile.writeText("""
             plugins {
                 id 'org.springframework.boot' version '2.2.4.RELEASE'
@@ -253,7 +252,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
             }
             
             ext {
-                set('vaadinVersion', "$vaadin16Version")
+                set('vaadinVersion', "$vaadin17Version")
             }
             
             configurations {
@@ -312,7 +311,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
             import com.vaadin.flow.component.page.AppShellConfigurator;
             import com.vaadin.flow.server.PWA;
 
-            @PWA(name = "Demo application", shortName = "Demo", enableInstallPrompt = false)
+            @PWA(name = "Demo application", shortName = "Demo")
             public class AppShell implements AppShellConfigurator {
             }
         """.trimIndent())
@@ -342,8 +341,8 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                 maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
             }
             dependencies {
-                // Vaadin 16
-                compile("com.vaadin:vaadin-core:$vaadin16Version") {
+                // Vaadin 17
+                compile("com.vaadin:vaadin-core:$vaadin17Version") {
             //         Webjars are only needed when running in Vaadin 13 compatibility mode
                     ["com.vaadin.webjar", "org.webjars.bowergithub.insites",
                      "org.webjars.bowergithub.polymer", "org.webjars.bowergithub.polymerelements",
@@ -394,7 +393,6 @@ class MiscSingleModuleTest : AbstractGradleTest() {
      * https://github.com/vaadin/vaadin-gradle-plugin/issues/76
      */
     @Test
-    @Ignore("nodeVersion and nodeDownloadRoot options are not supported in flow 3.1")
     fun testNodeDownload() {
         // Vaadin downloads the node here. Delete the folder so that Vaadin is forced to download the node again
         if (!FrontendUtils.getVaadinHomeDirectory().deleteRecursively()) {
@@ -409,8 +407,8 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                 jcenter()
             }
             dependencies {
-                // Vaadin 14
-                compile("com.vaadin:vaadin-core:$vaadin14Version") {
+                // Vaadin 17
+                compile("com.vaadin:vaadin-core:$vaadin17Version") {
             //         Webjars are only needed when running in Vaadin 13 compatibility mode
                     ["com.vaadin.webjar", "org.webjars.bowergithub.insites",
                      "org.webjars.bowergithub.polymer", "org.webjars.bowergithub.polymerelements",

--- a/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
+++ b/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
@@ -4,6 +4,7 @@ import com.vaadin.flow.server.frontend.FrontendUtils
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Ignore
 import org.junit.Test
 import java.io.File
 import java.io.IOException
@@ -55,8 +56,8 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                 maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
             }
             dependencies {
-                // Vaadin 14
-                compile("com.vaadin:vaadin-core:$vaadin14Version") {
+                // Vaadin 16
+                compile("com.vaadin:vaadin-core:$vaadin16Version") {
             //         Webjars are only needed when running in Vaadin 13 compatibility mode
                     ["com.vaadin.webjar", "org.webjars.bowergithub.insites",
                      "org.webjars.bowergithub.polymer", "org.webjars.bowergithub.polymerelements",
@@ -100,8 +101,8 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                 optimizeBundle = true
             }
             dependencies {
-                // Vaadin 14
-                compile("com.vaadin:vaadin-core:$vaadin14Version") {
+                // Vaadin 16
+                compile("com.vaadin:vaadin-core:$vaadin16Version") {
             //         Webjars are only needed when running in Vaadin 13 compatibility mode
                     ["com.vaadin.webjar", "org.webjars.bowergithub.insites",
                      "org.webjars.bowergithub.polymer", "org.webjars.bowergithub.polymerelements",
@@ -144,8 +145,8 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                 optimizeBundle = true
             }
             dependencies {
-                // Vaadin 14
-                compile("com.vaadin:vaadin-core:$vaadin14Version") {
+                // Vaadin 16
+                compile("com.vaadin:vaadin-core:$vaadin16Version") {
             //         Webjars are only needed when running in Vaadin 13 compatibility mode
                     ["com.vaadin.webjar", "org.webjars.bowergithub.insites",
                      "org.webjars.bowergithub.polymer", "org.webjars.bowergithub.polymerelements",
@@ -195,8 +196,8 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                 optimizeBundle = true
             }
             dependencies {
-                // Vaadin 14
-                compile("com.vaadin:vaadin-core:$vaadin14Version") {
+                // Vaadin 16
+                compile("com.vaadin:vaadin-core:$vaadin16Version") {
             //         Webjars are only needed when running in Vaadin 13 compatibility mode
                     ["com.vaadin.webjar", "org.webjars.bowergithub.insites",
                      "org.webjars.bowergithub.polymer", "org.webjars.bowergithub.polymerelements",
@@ -237,7 +238,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
      * This build script covers the [Spring Boot example](https://github.com/vaadin/base-starter-spring-gradle)
      */
     @Test
-    fun testVaadin14SpringProjectProductionMode() {
+    fun testVaadin16SpringProjectProductionMode() {
         buildFile.writeText("""
             plugins {
                 id 'org.springframework.boot' version '2.2.4.RELEASE'
@@ -252,7 +253,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
             }
             
             ext {
-                set('vaadinVersion', "$vaadin14Version")
+                set('vaadinVersion', "$vaadin16Version")
             }
             
             configurations {
@@ -286,6 +287,8 @@ class MiscSingleModuleTest : AbstractGradleTest() {
         // need to create the Application.java file otherwise bootJar will fail
         val appPkg = File(testProjectDir, "src/main/java/com/example/demo")
         Files.createDirectories(appPkg.toPath())
+
+        // DemoApplication.java file creation
         File(appPkg, "DemoApplication.java").writeText("""
             package com.example.demo;
             
@@ -299,6 +302,18 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                     SpringApplication.run(DemoApplication.class, args);
                 }
             
+            }
+        """.trimIndent())
+
+        // AppShell.java file creation
+        File(appPkg, "AppShell.java").writeText("""
+            package com.example.demo;
+            
+            import com.vaadin.flow.component.page.AppShellConfigurator;
+            import com.vaadin.flow.server.PWA;
+
+            @PWA(name = "Demo application", shortName = "Demo", enableInstallPrompt = false)
+            public class AppShell implements AppShellConfigurator {
             }
         """.trimIndent())
 
@@ -327,8 +342,8 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                 maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
             }
             dependencies {
-                // Vaadin 14
-                compile("com.vaadin:vaadin-core:$vaadin14Version") {
+                // Vaadin 16
+                compile("com.vaadin:vaadin-core:$vaadin16Version") {
             //         Webjars are only needed when running in Vaadin 13 compatibility mode
                     ["com.vaadin.webjar", "org.webjars.bowergithub.insites",
                      "org.webjars.bowergithub.polymer", "org.webjars.bowergithub.polymerelements",
@@ -379,6 +394,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
      * https://github.com/vaadin/vaadin-gradle-plugin/issues/76
      */
     @Test
+    @Ignore("nodeVersion and nodeDownloadRoot options are not supported in flow 3.1")
     fun testNodeDownload() {
         // Vaadin downloads the node here. Delete the folder so that Vaadin is forced to download the node again
         if (!FrontendUtils.getVaadinHomeDirectory().deleteRecursively()) {

--- a/src/functionalTest/kotlin/com/vaadin/gradle/TestUtils.kt
+++ b/src/functionalTest/kotlin/com/vaadin/gradle/TestUtils.kt
@@ -136,9 +136,7 @@ fun expectArchiveContainsVaadinWebpackBundle(archive: File,
             "${resourcePackaging}META-INF/VAADIN/config/flow-build-info.json",
             "${resourcePackaging}META-INF/VAADIN/config/stats.json",
             "${resourcePackaging}META-INF/VAADIN/build/*.gz",
-            "${resourcePackaging}META-INF/VAADIN/build/*.js",
-            "${resourcePackaging}META-INF/VAADIN/build/webcomponentsjs/webcomponents-*.js",
-            "${resourcePackaging}META-INF/VAADIN/build/webcomponentsjs/bundles/webcomponents-*.js"
+            "${resourcePackaging}META-INF/VAADIN/build/*.js"
     ) { archive }
     if (!isStandaloneJar) {
         val libPrefix: String = if (isSpringBootJar) "BOOT-INF/lib" else "WEB-INF/lib"
@@ -157,7 +155,7 @@ fun expectArchiveContainsVaadinWebpackBundle(archive: File,
  * the `META-INF/VAADIN/build/` directory.
  */
 fun expectArchiveDoesntContainVaadinWebpackBundle(archive: File,
-                                             isSpringBootJar: Boolean) {
+                                                  isSpringBootJar: Boolean) {
     val isWar: Boolean = archive.name.endsWith(".war", true)
     val isStandaloneJar: Boolean = !isWar && !isSpringBootJar
     val resourcePackaging: String = when {
@@ -168,9 +166,7 @@ fun expectArchiveDoesntContainVaadinWebpackBundle(archive: File,
     expectArchiveContains("${resourcePackaging}META-INF/VAADIN/config/flow-build-info.json") { archive }
     expectArchiveDoesntContain("${resourcePackaging}META-INF/VAADIN/config/stats.json",
             "${resourcePackaging}META-INF/VAADIN/build/*.gz",
-            "${resourcePackaging}META-INF/VAADIN/build/*.js",
-            "${resourcePackaging}META-INF/VAADIN/build/webcomponentsjs/webcomponents-*.js",
-            "${resourcePackaging}META-INF/VAADIN/build/webcomponentsjs/bundles/webcomponents-*.js"
+            "${resourcePackaging}META-INF/VAADIN/build/*.js"
     ) { archive }
 
     if (!isStandaloneJar) {

--- a/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
+++ b/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
@@ -41,8 +41,8 @@ class VaadinSmokeTest : AbstractGradleTest() {
                 jcenter()
             }
             dependencies {
-                // Vaadin 16
-                compile("com.vaadin:vaadin-core:$vaadin16Version") {
+                // Vaadin 17
+                compile("com.vaadin:vaadin-core:$vaadin17Version") {
             //         Webjars are only needed when running in Vaadin 13 compatibility mode
                     ["com.vaadin.webjar", "org.webjars.bowergithub.insites",
                      "org.webjars.bowergithub.polymer", "org.webjars.bowergithub.polymerelements",

--- a/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
+++ b/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
@@ -89,8 +89,8 @@ class VaadinSmokeTest : AbstractGradleTest() {
 
         val build = File(testProjectDir, "build/resources/main/META-INF/VAADIN/build")
         expect(true, build.toString()) { build.exists() }
-        build.find("*.gz", 5..8)
-        build.find("*.js", 5..8)
+        build.find("*.gz", 5..10)
+        build.find("*.js", 5..10)
 
         val tokenFile = File(build, "../config/flow-build-info.json")
         val buildInfo: JsonObject = JsonUtil.parse(tokenFile.readText())
@@ -107,8 +107,8 @@ class VaadinSmokeTest : AbstractGradleTest() {
         val build = File(testProjectDir, "build/resources/main/META-INF/VAADIN/build")
         expect(true, build.toString()) { build.isDirectory }
         expect(true) { build.listFiles()!!.isNotEmpty() }
-        build.find("*.gz", 5..8)
-        build.find("*.js", 5..8)
+        build.find("*.gz", 5..10)
+        build.find("*.js", 5..10)
     }
 
     /**

--- a/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
+++ b/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
@@ -125,4 +125,16 @@ class VaadinSmokeTest : AbstractGradleTest() {
         // don't delete webpack.config.js: https://github.com/vaadin/vaadin-gradle-plugin/pull/74#discussion_r444457296
         expect(true) { webpackConfigJs.exists() }
     }
+
+    /**
+     * Tests that VaadinClean task removes TS-related files.
+     */
+    @Test
+    fun vaadinCleanDeleteTsFiles() {
+        val tsconfigJson = testProjectDir.touch("tsconfig.json")
+        val typesDTs = testProjectDir.touch("types.d.ts")
+        build("vaadinClean")
+        expect(false) { tsconfigJson.exists() }
+        expect(false) { typesDTs.exists() }
+    }
 }

--- a/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
+++ b/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
@@ -39,6 +39,7 @@ class VaadinSmokeTest : AbstractGradleTest() {
             }
             repositories {
                 jcenter()
+                maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
             }
             dependencies {
                 // Vaadin 17

--- a/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
+++ b/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
@@ -41,8 +41,8 @@ class VaadinSmokeTest : AbstractGradleTest() {
                 jcenter()
             }
             dependencies {
-                // Vaadin 14
-                compile("com.vaadin:vaadin-core:$vaadin14Version") {
+                // Vaadin 16
+                compile("com.vaadin:vaadin-core:$vaadin16Version") {
             //         Webjars are only needed when running in Vaadin 13 compatibility mode
                     ["com.vaadin.webjar", "org.webjars.bowergithub.insites",
                      "org.webjars.bowergithub.polymer", "org.webjars.bowergithub.polymerelements",
@@ -88,10 +88,8 @@ class VaadinSmokeTest : AbstractGradleTest() {
 
         val build = File(testProjectDir, "build/resources/main/META-INF/VAADIN/build")
         expect(true, build.toString()) { build.exists() }
-        build.find("*.gz", 5..7)
-        build.find("*.js", 5..7)
-        build.find("webcomponentsjs/webcomponents-*.js", 2..2)
-        build.find("webcomponentsjs/bundles/webcomponents-*.js", 4..4)
+        build.find("*.gz", 5..8)
+        build.find("*.js", 5..8)
 
         val tokenFile = File(build, "../config/flow-build-info.json")
         val buildInfo: JsonObject = JsonUtil.parse(tokenFile.readText())
@@ -108,10 +106,8 @@ class VaadinSmokeTest : AbstractGradleTest() {
         val build = File(testProjectDir, "build/resources/main/META-INF/VAADIN/build")
         expect(true, build.toString()) { build.isDirectory }
         expect(true) { build.listFiles()!!.isNotEmpty() }
-        build.find("*.gz", 5..7)
-        build.find("*.js", 5..7)
-        build.find("webcomponentsjs/webcomponents-*.js", 2..2)
-        build.find("webcomponentsjs/bundles/webcomponents-*.js", 4..4)
+        build.find("*.gz", 5..8)
+        build.find("*.js", 5..8)
     }
 
     /**

--- a/src/main/kotlin/com/vaadin/gradle/ReflectionsClassFinder.kt
+++ b/src/main/kotlin/com/vaadin/gradle/ReflectionsClassFinder.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.gradle
+
+import com.vaadin.flow.server.frontend.scanner.ClassFinder
+import org.reflections.Reflections
+import org.reflections.util.ConfigurationBuilder
+import java.lang.annotation.Repeatable
+import java.lang.reflect.AnnotatedElement
+import java.net.URL
+import java.net.URLClassLoader
+
+/**
+ * A class finder using org.reflections.
+ *
+ * @param urls
+ *            the list of urls for finding classes.
+ *
+ * @since 2.0
+ */
+class ReflectionsClassFinder(vararg urls: URL?) : ClassFinder {
+    @Transient
+    private val classLoader: ClassLoader
+
+    @Transient
+    private val reflections: Reflections
+
+    init {
+        classLoader = URLClassLoader(urls, null) // NOSONAR
+        reflections = Reflections(
+                ConfigurationBuilder().addClassLoader(classLoader)
+                        .setExpandSuperTypes(false).addUrls(*urls))
+    }
+
+    override fun getAnnotatedClasses(
+            clazz: Class<out Annotation?>): Set<Class<*>> {
+        val classes: MutableSet<Class<*>> = HashSet()
+        classes.addAll(reflections.getTypesAnnotatedWith(clazz, true))
+        classes.addAll(getAnnotatedByRepeatedAnnotation(clazz))
+        return classes
+    }
+
+    private fun getAnnotatedByRepeatedAnnotation(
+            annotationClass: AnnotatedElement): Set<Class<*>> {
+        val repeatableAnnotation = annotationClass
+                .getAnnotation(Repeatable::class.java)
+        return if (repeatableAnnotation != null) {
+            reflections.getTypesAnnotatedWith(
+                    repeatableAnnotation.value.java, true)
+        } else emptySet()
+    }
+
+    override fun getResource(name: String): URL? = classLoader.getResource(name)
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T> loadClass(name: String): Class<T> = classLoader.loadClass(name) as Class<T>
+
+    override fun <T> getSubTypesOf(type: Class<T>): Set<Class<out T>> = reflections.getSubTypesOf(type)
+
+    override fun getClassLoader(): ClassLoader = classLoader
+}

--- a/src/main/kotlin/com/vaadin/gradle/VaadinBuildFrontendTask.kt
+++ b/src/main/kotlin/com/vaadin/gradle/VaadinBuildFrontendTask.kt
@@ -16,6 +16,7 @@
 package com.vaadin.gradle
 
 import com.vaadin.flow.server.Constants
+import com.vaadin.flow.server.InitParameters
 import com.vaadin.flow.server.frontend.FrontendTools
 import com.vaadin.flow.server.frontend.FrontendUtils
 import com.vaadin.flow.server.frontend.FrontendUtils.DEAULT_FLOW_RESOURCES_FOLDER
@@ -146,16 +147,16 @@ open class VaadinBuildFrontendTask : DefaultTask() {
             remove(Constants.NPM_TOKEN)
             remove(Constants.GENERATED_TOKEN)
             remove(Constants.FRONTEND_TOKEN)
-            remove(Constants.SERVLET_PARAMETER_ENABLE_PNPM)
-            remove(Constants.REQUIRE_HOME_NODE_EXECUTABLE)
-            remove(Constants.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE);
+            remove(InitParameters.SERVLET_PARAMETER_ENABLE_PNPM)
+            remove(InitParameters.REQUIRE_HOME_NODE_EXECUTABLE)
+            remove(InitParameters.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE);
             remove(Constants.CONNECT_JAVA_SOURCE_FOLDER_TOKEN);
             remove(Constants.CONNECT_APPLICATION_PROPERTIES_TOKEN);
             remove(Constants.CONNECT_JAVA_SOURCE_FOLDER_TOKEN);
             remove(Constants.CONNECT_OPEN_API_FILE_TOKEN);
             remove(Constants.CONNECT_GENERATED_TS_DIR_TOKEN);
 
-            put(Constants.SERVLET_PARAMETER_ENABLE_DEV_SERVER, false)
+            put(InitParameters.SERVLET_PARAMETER_ENABLE_DEV_SERVER, false)
         }
         buildInfo.writeToFile(tokenFile)
         logger.info("Updated token file $tokenFile to $buildInfo")

--- a/src/main/kotlin/com/vaadin/gradle/VaadinBuildFrontendTask.kt
+++ b/src/main/kotlin/com/vaadin/gradle/VaadinBuildFrontendTask.kt
@@ -18,7 +18,7 @@ package com.vaadin.gradle
 import com.vaadin.flow.server.Constants
 import com.vaadin.flow.server.frontend.FrontendTools
 import com.vaadin.flow.server.frontend.FrontendUtils
-import com.vaadin.flow.server.frontend.NodeTasks
+import com.vaadin.flow.server.frontend.FrontendUtils.DEAULT_FLOW_RESOURCES_FOLDER
 import elemental.json.JsonObject
 import elemental.json.impl.JsonUtil
 import org.gradle.api.DefaultTask
@@ -110,16 +110,25 @@ open class VaadinBuildFrontendTask : DefaultTask() {
         logger.info("runNodeUpdater: enableImportsUpdate=true, embeddableWebComponents=${extension.generateEmbeddableWebComponents}, tokenFile=${tokenFile}")
         logger.info("runNodeUpdater: pnpm=${extension.pnpmEnable}, requireHomeNodeExec=${extension.requireHomeNodeExec}")
 
+        val flowResourcesFolder = File(extension.npmFolder, DEAULT_FLOW_RESOURCES_FOLDER)
+        // @formatter:off
         extension.createNodeTasksBuilder(project)
                 .runNpmInstall(extension.runNpmInstall)
+                .useV14Bootstrap(extension.useDeprecatedV14Bootstrapping)
                 .enablePackagesUpdate(true)
                 .useByteCodeScanner(extension.optimizeBundle)
+                .withFlowResourcesFolder(flowResourcesFolder)
                 .copyResources(jarFiles)
                 .copyLocalResources(extension.frontendResourcesDirectory)
                 .enableImportsUpdate(true)
                 .withEmbeddableWebComponents(extension.generateEmbeddableWebComponents)
                 .withTokenFile(tokenFile)
                 .enablePnpm(extension.pnpmEnable)
+                .withConnectApplicationProperties(extension.applicationProperties)
+                .withConnectJavaSourceFolder(extension.javaSourceFolder)
+                .withConnectGeneratedOpenApiJson(extension.openApiJsonFile)
+                .withConnectClientTsApiFolder(extension.generatedTsFolder)
+                .withHomeNodeExecRequired(extension.requireHomeNodeExec)
                 .build().execute()
 
         logger.info("runNodeUpdater: done!")
@@ -140,6 +149,13 @@ open class VaadinBuildFrontendTask : DefaultTask() {
             remove(Constants.FRONTEND_TOKEN)
             remove(Constants.SERVLET_PARAMETER_ENABLE_PNPM)
             remove(Constants.REQUIRE_HOME_NODE_EXECUTABLE)
+            remove(Constants.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE);
+            remove(Constants.CONNECT_JAVA_SOURCE_FOLDER_TOKEN);
+            remove(Constants.CONNECT_APPLICATION_PROPERTIES_TOKEN);
+            remove(Constants.CONNECT_JAVA_SOURCE_FOLDER_TOKEN);
+            remove(Constants.CONNECT_OPEN_API_FILE_TOKEN);
+            remove(Constants.CONNECT_GENERATED_TS_DIR_TOKEN);
+
             put(Constants.SERVLET_PARAMETER_ENABLE_DEV_SERVER, false)
         }
         buildInfo.writeToFile(tokenFile)

--- a/src/main/kotlin/com/vaadin/gradle/VaadinBuildFrontendTask.kt
+++ b/src/main/kotlin/com/vaadin/gradle/VaadinBuildFrontendTask.kt
@@ -128,7 +128,6 @@ open class VaadinBuildFrontendTask : DefaultTask() {
                 .withConnectJavaSourceFolder(extension.javaSourceFolder)
                 .withConnectGeneratedOpenApiJson(extension.openApiJsonFile)
                 .withConnectClientTsApiFolder(extension.generatedTsFolder)
-                .withHomeNodeExecRequired(extension.requireHomeNodeExec)
                 .build().execute()
 
         logger.info("runNodeUpdater: done!")

--- a/src/main/kotlin/com/vaadin/gradle/VaadinCleanTask.kt
+++ b/src/main/kotlin/com/vaadin/gradle/VaadinCleanTask.kt
@@ -28,6 +28,8 @@ import org.gradle.api.tasks.TaskAction
  * * `webpack.generated.js`
  * * `package-lock.yaml` (used by Vaadin 14.2+ pnpm)
  * * `pnpm-file.js` (used by Vaadin 14.2+ pnpm)
+ * * `tsconfig.json` (used by Vaadin 15+)
+ * * `types.d.ts` (used by Vaadin 15+)
  *
  * Doesn't delete `webpack.config.js` since it is intended to contain
  * user-specific code. See https://github.com/vaadin/vaadin-gradle-plugin/issues/43
@@ -40,7 +42,8 @@ import org.gradle.api.tasks.TaskAction
 open class VaadinCleanTask : DefaultTask() {
     init {
         group = "Vaadin"
-        description = "Cleans the project completely and removes node_modules, package*.json and webpack.*.js"
+        description = "Cleans the project completely and removes node_modules, webpack.generated.js, " +
+                      "tsconfig.json, types.d.ts, pnpm-lock.yaml, pnpmfile.js, package*.json and webpack.*.js"
 
         dependsOn("clean")
     }
@@ -52,7 +55,9 @@ open class VaadinCleanTask : DefaultTask() {
                 "${project.projectDir}/package-lock.json",
                 "${project.projectDir}/webpack.generated.js",
                 "${project.projectDir}/pnpm-lock.yaml", // used by Vaadin 14.2+ pnpm
-                "${project.projectDir}/pnpmfile.js" // used by Vaadin 14.2+ pnpm
+                "${project.projectDir}/pnpmfile.js", // used by Vaadin 14.2+ pnpm
+                "${project.projectDir}/tsconfig.json", // used by Vaadin 15+
+                "${project.projectDir}/types.d.ts" // used by Vaadin 15+
         )
     }
 }

--- a/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -16,7 +16,9 @@
 package com.vaadin.gradle
 
 import com.vaadin.flow.server.Constants
+import com.vaadin.flow.server.frontend.FrontendTools
 import com.vaadin.flow.server.frontend.FrontendUtils
+import com.vaadin.flow.server.frontend.installer.NodeInstaller
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.SourceSetContainer
@@ -156,6 +158,21 @@ open class VaadinFlowPluginExtension(project: Project) {
      * The folder where flow will put TS API files for client projects.
      */
     var generatedTsFolder = File(project.projectDir, "frontend/generated")
+
+    /**
+     * The node.js version to be used when node.js is installed automatically by
+     * Vaadin, for example `"v12.16.0"`. Defaults to [FrontendTools.DEFAULT_NODE_VERSION].
+     */
+    var nodeVersion: String = FrontendTools.DEFAULT_NODE_VERSION
+
+    /**
+     * Download node.js from this URL. Handy in heavily firewalled corporate
+     * environments where the node.js download can be provided from an intranet
+     * mirror. Defaults to [NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT].
+     *
+     * Example: `"https://nodejs.org/dist/"`.
+     */
+    var nodeDownloadRoot: String = NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT
 
     companion object {
         fun get(project: Project): VaadinFlowPluginExtension =

--- a/src/main/kotlin/com/vaadin/gradle/VaadinPrepareFrontendTask.kt
+++ b/src/main/kotlin/com/vaadin/gradle/VaadinPrepareFrontendTask.kt
@@ -16,6 +16,7 @@
 package com.vaadin.gradle
 
 import com.vaadin.flow.server.Constants
+import com.vaadin.flow.server.InitParameters
 import com.vaadin.flow.server.frontend.FrontendTools
 import com.vaadin.flow.server.frontend.FrontendUtils
 import com.vaadin.flow.server.frontend.NodeTasks
@@ -117,9 +118,9 @@ open class VaadinPrepareFrontendTask : DefaultTask() {
         val configFolder = File("${extension.buildOutputDirectory}/META-INF/VAADIN/config")
         Files.createDirectories(configFolder.toPath())
         val buildInfo: JsonObject = Json.createObject().apply {
-            put(Constants.SERVLET_PARAMETER_PRODUCTION_MODE, extension.productionMode)
-            put(Constants.SERVLET_PARAMETER_USE_V14_BOOTSTRAP, extension.useDeprecatedV14Bootstrapping);
-            put(Constants.SERVLET_PARAMETER_INITIAL_UIDL, extension.eagerServerLoad);
+            put(InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE, extension.productionMode)
+            put(InitParameters.SERVLET_PARAMETER_USE_V14_BOOTSTRAP, extension.useDeprecatedV14Bootstrapping);
+            put(InitParameters.SERVLET_PARAMETER_INITIAL_UIDL, extension.eagerServerLoad);
             put(Constants.NPM_TOKEN, extension.npmFolder.absolutePath)
             put(Constants.GENERATED_TOKEN, extension.generatedFolder.absolutePath)
             put(Constants.FRONTEND_TOKEN, extension.frontendDirectory.absolutePath)
@@ -127,8 +128,8 @@ open class VaadinPrepareFrontendTask : DefaultTask() {
             put(Constants.CONNECT_APPLICATION_PROPERTIES_TOKEN, extension.applicationProperties.absolutePath);
             put(Constants.CONNECT_OPEN_API_FILE_TOKEN, extension.openApiJsonFile.absolutePath);
             put(Constants.CONNECT_GENERATED_TS_DIR_TOKEN, extension.generatedTsFolder.absolutePath);
-            put(Constants.SERVLET_PARAMETER_ENABLE_PNPM, extension.pnpmEnable)
-            put(Constants.REQUIRE_HOME_NODE_EXECUTABLE, extension.requireHomeNodeExec)
+            put(InitParameters.SERVLET_PARAMETER_ENABLE_PNPM, extension.pnpmEnable)
+            put(InitParameters.REQUIRE_HOME_NODE_EXECUTABLE, extension.requireHomeNodeExec)
         }
         val tokenFile = File(configFolder, "flow-build-info.json")
         buildInfo.writeToFile(tokenFile)

--- a/src/main/kotlin/com/vaadin/gradle/VaadinPrepareFrontendTask.kt
+++ b/src/main/kotlin/com/vaadin/gradle/VaadinPrepareFrontendTask.kt
@@ -17,6 +17,7 @@ package com.vaadin.gradle
 
 import com.vaadin.flow.server.Constants
 import com.vaadin.flow.server.frontend.FrontendTools
+import com.vaadin.flow.server.frontend.FrontendUtils
 import com.vaadin.flow.server.frontend.NodeTasks
 import elemental.json.Json
 import elemental.json.JsonObject
@@ -82,8 +83,12 @@ open class VaadinPrepareFrontendTask : DefaultTask() {
         logger.info("runNodeUpdater: withWebpack(${extension.webpackOutputDirectory}, ${extension.webpackTemplate}, ${extension.webpackGeneratedTemplate})")
         logger.info("runNodeUpdater: createMissingPackageJson(true), enableImportsUpdate(false), enablePackagesUpdate(false)")
         logger.info("runNodeUpdater: not running npm install: it's supposed to be run either by Vaadin Servlet in development mode, or by the `vaadinBuildFrontend` task.")
+
+        val flowResourcesFolder = File(extension.npmFolder, FrontendUtils.DEAULT_FLOW_RESOURCES_FOLDER)
         val builder: NodeTasks.Builder = extension.createNodeTasksBuilder(project)
                 .withWebpack(extension.webpackOutputDirectory!!, extension.webpackTemplate, extension.webpackGeneratedTemplate)
+                .useV14Bootstrap(extension.useDeprecatedV14Bootstrapping)
+                .withFlowResourcesFolder(flowResourcesFolder)
                 .createMissingPackageJson(true)
                 .enableImportsUpdate(false)
                 .enablePackagesUpdate(false)
@@ -112,11 +117,16 @@ open class VaadinPrepareFrontendTask : DefaultTask() {
         val configFolder = File("${extension.buildOutputDirectory}/META-INF/VAADIN/config")
         Files.createDirectories(configFolder.toPath())
         val buildInfo: JsonObject = Json.createObject().apply {
-            put(Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE, false)
             put(Constants.SERVLET_PARAMETER_PRODUCTION_MODE, extension.productionMode)
+            put(Constants.SERVLET_PARAMETER_USE_V14_BOOTSTRAP, extension.useDeprecatedV14Bootstrapping);
+            put(Constants.SERVLET_PARAMETER_INITIAL_UIDL, extension.eagerServerLoad);
             put(Constants.NPM_TOKEN, extension.npmFolder.absolutePath)
             put(Constants.GENERATED_TOKEN, extension.generatedFolder.absolutePath)
             put(Constants.FRONTEND_TOKEN, extension.frontendDirectory.absolutePath)
+            put(Constants.CONNECT_JAVA_SOURCE_FOLDER_TOKEN, extension.javaSourceFolder.absolutePath);
+            put(Constants.CONNECT_APPLICATION_PROPERTIES_TOKEN, extension.applicationProperties.absolutePath);
+            put(Constants.CONNECT_OPEN_API_FILE_TOKEN, extension.openApiJsonFile.absolutePath);
+            put(Constants.CONNECT_GENERATED_TS_DIR_TOKEN, extension.generatedTsFolder.absolutePath);
             put(Constants.SERVLET_PARAMETER_ENABLE_PNPM, extension.pnpmEnable)
             put(Constants.REQUIRE_HOME_NODE_EXECUTABLE, extension.requireHomeNodeExec)
         }

--- a/src/main/kotlin/com/vaadin/gradle/VaadinUtils.kt
+++ b/src/main/kotlin/com/vaadin/gradle/VaadinUtils.kt
@@ -145,7 +145,12 @@ internal fun Collection<File>.toPrettyFormat(): String = joinToString(prefix = "
 
 internal fun VaadinFlowPluginExtension.createFrontendTools(): FrontendTools =
         FrontendTools(npmFolder.absolutePath,
-                Supplier { FrontendUtils.getVaadinHomeDirectory().absolutePath })
+                Supplier { FrontendUtils.getVaadinHomeDirectory().absolutePath },
+                nodeVersion,
+                URI(nodeDownloadRoot))
 
 internal fun VaadinFlowPluginExtension.createNodeTasksBuilder(project: Project): NodeTasks.Builder =
         NodeTasks.Builder(getClassFinder(project), npmFolder, generatedFolder, frontendDirectory)
+                .withHomeNodeExecRequired(requireHomeNodeExec)
+                .withNodeVersion(nodeVersion)
+                .withNodeDownloadRoot(URI(nodeDownloadRoot))

--- a/src/main/kotlin/com/vaadin/gradle/VaadinUtils.kt
+++ b/src/main/kotlin/com/vaadin/gradle/VaadinUtils.kt
@@ -114,7 +114,7 @@ internal fun JsonObject.writeToFile(file: File, indentation: Int = 2) {
  *
  * @param propertyName the property name
  *
- * @return `null` if the property is not present, `true` it's defined or if it's set to "true"
+ * @return `null` if the property is not present, `true` if it's defined or if it's set to "true"
  * and `false` otherwise.
  */
 fun Project.getBooleanProperty(propertyName: String) : Boolean? {

--- a/src/main/kotlin/com/vaadin/gradle/VaadinUtils.kt
+++ b/src/main/kotlin/com/vaadin/gradle/VaadinUtils.kt
@@ -19,7 +19,6 @@ import com.vaadin.flow.server.frontend.FrontendTools
 import com.vaadin.flow.server.frontend.FrontendUtils
 import com.vaadin.flow.server.frontend.NodeTasks
 import com.vaadin.flow.server.frontend.scanner.ClassFinder
-import com.vaadin.flow.server.scanner.ReflectionsClassFinder
 import elemental.json.JsonObject
 import elemental.json.impl.JsonUtil
 import org.gradle.api.Project
@@ -109,6 +108,28 @@ internal fun JsonObject.writeToFile(file: File, indentation: Int = 2) {
 }
 
 /**
+ * Finds the value of a boolean property. It searches in gradle and system properties.
+ *
+ * If the property is defined in both gradle and system properties, then the gradle property is taken.
+ *
+ * @param propertyName the property name
+ *
+ * @return `null` if the property is not present, `true` it's defined or if it's set to "true"
+ * and `false` otherwise.
+ */
+fun Project.getBooleanProperty(propertyName: String) : Boolean? {
+    if (project.hasProperty(propertyName)) {
+        val property: String = project.property(propertyName) as String
+        return property.isBlank() || property.toBoolean()
+    }
+    if (System.getProperty(propertyName) != null) {
+        val property: String = System.getProperty(propertyName)
+        return property.isBlank() || property.toBoolean()
+    }
+    return null
+}
+
+/**
  * Allows Kotlin-based gradle scripts to be configured via
  * ```
  * vaadin {
@@ -124,12 +145,7 @@ internal fun Collection<File>.toPrettyFormat(): String = joinToString(prefix = "
 
 internal fun VaadinFlowPluginExtension.createFrontendTools(): FrontendTools =
         FrontendTools(npmFolder.absolutePath,
-                Supplier { FrontendUtils.getVaadinHomeDirectory().absolutePath },
-                nodeVersion,
-                URI(nodeDownloadRoot))
+                Supplier { FrontendUtils.getVaadinHomeDirectory().absolutePath })
 
 internal fun VaadinFlowPluginExtension.createNodeTasksBuilder(project: Project): NodeTasks.Builder =
         NodeTasks.Builder(getClassFinder(project), npmFolder, generatedFolder, frontendDirectory)
-                .withHomeNodeExecRequired(requireHomeNodeExec)
-                .withNodeVersion(nodeVersion)
-                .withNodeDownloadRoot(URI(nodeDownloadRoot))


### PR DESCRIPTION
Gradle  Kotlin Vaadin are Awesome :-D

This PR Fixes #69, Fixes #50 and Fixes #56 

We are planning to start a projet with gradle and vaadin 16 and actually vaadin-gradle-plugin doesn't support vaadin 15/16.

So this PR is to add support of V15/16

Edit : This PR will also target supporting vaadin 17