### PR TITLE
kotlin v bump

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ plugins {
 	id 'maven-publish'
     id 'idea'
     id 'com.gradle.plugin-publish' version '0.11.0'
-    id 'org.jetbrains.kotlin.jvm' version '1.3.72'
+    id 'org.jetbrains.kotlin.jvm' version '1.4.0'
 }
 
 /***********************************************************************************************************************
@@ -73,12 +73,12 @@ repositories {
 }
 
 dependencies {
-    compile("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72")
+    compile("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.0")
     compile("com.vaadin:flow-migration:2.3.0")
     compile("org.zeroturnaround:zt-exec:1.11")
 
     testCompile("junit:junit:4.12")
-    testCompile("org.jetbrains.kotlin:kotlin-test:1.3.72")
+    testCompile("org.jetbrains.kotlin:kotlin-test:1.4.0")
 }
 
 idea {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Kotlin v-bump to 1.4.0

Also v-bumping Gradle to 5.3.0 as required by the Kotlin 1.4.0 plugin. I think at some point we would have to upgrade Gradle anyway.